### PR TITLE
refactor(ui): Modularize UI components and fix tab rendering

### DIFF
--- a/crates/rtfm-core/tests/test_app_state.rs
+++ b/crates/rtfm-core/tests/test_app_state.rs
@@ -19,7 +19,7 @@ async fn test_clipboard_yank_and_paste() {
 
     let mut app_state = AppState::new();
     app_state.get_active_tab_mut().current_dir = tmp_dir.path().to_path_buf();
-    app_state.get_active_tab_mut().update_entries();
+    app_state.get_active_tab_mut().update_entries(false);
 
     // Yank the file
     app_state.get_active_tab_mut().cursor = 0; // Assuming the file is the first entry

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod tui;
 pub mod layout;
 pub mod left_pane;
+pub mod top_bar;
+pub mod right_pane;
+pub mod middle_pane;

--- a/crates/ui/src/middle_pane.rs
+++ b/crates/ui/src/middle_pane.rs
@@ -1,0 +1,36 @@
+use crate::right_pane;
+use ratatui::{
+    prelude::{Color, Rect, Style},
+    widgets::{List, ListItem, ListState},
+    Frame,
+};
+use rtfm_core::app_state::TabState;
+
+pub fn render_middle_pane(frame: &mut Frame, area: Rect, tab_state: &TabState) {
+    let items: Vec<ListItem> = tab_state
+        .entries
+        .iter()
+        .map(|entry| {
+            let is_hidden = entry.name.starts_with('.');
+            let style = if is_hidden {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+
+            let icon = right_pane::get_icon_for_path(&entry.path, entry.is_dir);
+            let mut name = format!("{} {}", icon, entry.name.clone());
+            if entry.is_dir {
+                name.push('/');
+            }
+            ListItem::new(name).style(style)
+        })
+        .collect();
+
+    let list = List::new(items).highlight_symbol(">> ");
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(tab_state.cursor));
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+}

--- a/crates/ui/src/right_pane.rs
+++ b/crates/ui/src/right_pane.rs
@@ -1,0 +1,63 @@
+use ratatui::{
+    prelude::{Color, Rect, Style},
+    widgets::{List, ListItem, Paragraph},
+    Frame,
+};
+use rtfm_core::{app_state::TabState, preview::PreviewState};
+use std::path::Path;
+
+pub fn get_icon_for_path(path: &Path, is_dir: bool) -> &'static str {
+    if is_dir {
+        return ""; // Folder icon
+    }
+    match path.extension().and_then(|s| s.to_str()) {
+        Some("jpg") | Some("jpeg") | Some("png") | Some("gif") | Some("bmp") => "", // Image icon
+        Some("zip") | Some("gz") | Some("tar") | Some("rar") | Some("7z") => "",    // Archive icon
+        Some("txt") | Some("md") => "", // Text file icon
+        Some("mp3") | Some("wav") | Some("flac") => "🎵", // Audio icon
+        Some("mp4") | Some("mkv") | Some("mov") | Some("avi") => "", // Video icon
+        Some("rs") | Some("js") | Some("html") | Some("css") | Some("py") | Some("toml")
+        | Some("sh") => "", // Code icon
+        _ => "", // Generic file icon
+    }
+}
+
+pub fn render_right_pane(frame: &mut Frame, area: Rect, tab_state: &TabState) {
+    let preview_state = tab_state.preview_state.lock().unwrap();
+
+    match &*preview_state {
+        PreviewState::Directory(entries) => {
+            let items: Vec<ListItem> = entries
+                .iter()
+                .map(|entry| {
+                    let is_hidden = entry.name.starts_with('.');
+                    let style = if is_hidden {
+                        Style::default().fg(Color::DarkGray)
+                    } else {
+                        Style::default()
+                    };
+
+                    let icon = get_icon_for_path(&entry.path, entry.is_dir);
+                    let mut name = format!("{} {}", icon, entry.name.clone());
+                    if entry.is_dir {
+                        name.push('/');
+                    }
+                    ListItem::new(name).style(style)
+                })
+                .collect();
+            let list = List::new(items);
+            frame.render_widget(list, area);
+        }
+        _ => {
+            let content = match &*preview_state {
+                PreviewState::Empty => "Empty",
+                PreviewState::Loading => "Loading...",
+                PreviewState::Text(text) => text,
+                PreviewState::Error(e) => e,
+                PreviewState::Directory(_) => unreachable!(),
+            };
+            let paragraph = Paragraph::new(content);
+            frame.render_widget(paragraph, area);
+        }
+    }
+}

--- a/crates/ui/src/top_bar.rs
+++ b/crates/ui/src/top_bar.rs
@@ -1,0 +1,37 @@
+use ratatui::{
+    prelude::{Rect, Style},
+    style::{Color, Modifier},
+    widgets::{Block, Borders, Tabs},
+    Frame,
+};
+
+use rtfm_core::app_state::AppState;
+
+pub fn render_top_bar(frame: &mut Frame, area: Rect, app_state: &AppState) {
+    let titles: Vec<String> = app_state
+        .tabs
+        .iter()
+        .map(|tab| {
+            format!(
+                "{} {}",
+                tab.id + 1,
+                tab.current_dir
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+            )
+        })
+        .collect();
+
+    let tabs = Tabs::new(titles)
+        .block(Block::default().borders(Borders::BOTTOM))
+        .select(app_state.active_tab_index)
+        .style(Style::default().fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    frame.render_widget(tabs, area);
+}


### PR DESCRIPTION
This commit addresses the issue where tabs were not being displayed in the top bar of the application. The fix involved a significant refactoring of the UI code to improve modularity and correct the rendering logic.

The main changes are:
- The monolithic `layout.rs` has been broken down into smaller, more focused modules: `top_bar.rs`, `middle_pane.rs`, and `right_pane.rs`. Each module is now responsible for rendering its specific part of the UI.
- The rendering logic for the tabs in `top_bar.rs` has been corrected. The original issue was caused by rendering a widget with borders into a layout area that was too small to accommodate both the content and the borders. The layout constraints have been adjusted to provide sufficient space, ensuring the tabs are now visible.
- The function signatures for rendering have been corrected to take an immutable `&AppState`, adhering to best practices for the `ratatui` library where rendering functions should not mutate state.

With these changes, the tabs are now correctly displayed, and the pre-existing keybindings for creating, closing, and switching tabs are now functional.