### PR TITLE
feat: Improve file deletion and UI refresh logic

### DIFF
--- a/crates/rtfm-core/src/app_state.rs
+++ b/crates/rtfm-core/src/app_state.rs
@@ -471,9 +471,21 @@ impl AppState {
 
     pub fn delete_selection(&mut self) {
         if let Some(path) = self.get_active_tab().get_selected_entry_path() {
-            self.path_to_delete = Some(path.clone());
-            self.confirmation_message = format!("Are you sure you want to delete {:?}? (y/n)", path.file_name().unwrap());
-            self.show_confirmation = true;
+            let is_dir = path.is_dir();
+            let is_empty = if is_dir {
+                fs::read_dir(&path).map(|mut dir| dir.next().is_none()).unwrap_or(false)
+            } else {
+                false
+            };
+
+            if is_dir && is_empty {
+                self.path_to_delete = Some(path);
+                self.confirm_delete();
+            } else {
+                self.path_to_delete = Some(path.clone());
+                self.confirmation_message = format!("Are you sure you want to delete {:?}? (y/n)", path.file_name().unwrap());
+                self.show_confirmation = true;
+            }
         }
     }
 


### PR DESCRIPTION
This commit introduces two main improvements to the file manager's user experience.

1.  Conditional Deletion Confirmation: The application no longer asks for confirmation when deleting an empty directory. A confirmation prompt is now only shown for deleting files or non-empty directories.

2.  Event-Driven UI Refresh: The main application loop has been refactored to be fully event-driven. The UI now refreshes immediately and automatically after any background file operation (e.g., delete, paste) completes. This provides instant visual feedback to the user. This was achieved by replacing the previous polling mechanism with a `tokio::select!` that listens for both user input and task completion events.