### PR TITLE
Fix UI refresh after paste/create operations

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -68,9 +68,11 @@ impl App {
                         break 'main;
                     }
                 }
-                _ = self.app_state.task_manager.wait_for_event() => {
-                    let show_hidden = self.app_state.show_hidden_files;
-                    self.app_state.get_active_tab_mut().update_entries(show_hidden);
+                task_completed = self.app_state.task_manager.wait_for_event() => {
+                    if task_completed {
+                        let show_hidden = self.app_state.show_hidden_files;
+                        self.app_state.get_active_tab_mut().update_entries(show_hidden);
+                    }
                 }
             }
         }

--- a/crates/rtfm-core/src/task_manager.rs
+++ b/crates/rtfm-core/src/task_manager.rs
@@ -108,21 +108,25 @@ impl TaskManager {
         }
     }
 
-    pub async fn wait_for_event(&mut self) {
+    pub async fn wait_for_event(&mut self) -> bool {
         if let Some((task_id, event)) = self.progress_rx.recv().await {
             let mut tasks = self.tasks.lock().unwrap();
             if let Some(task) = tasks.iter_mut().find(|t| t.id == task_id) {
                 match event {
                     fs_ops::ProgressEvent::Completed => {
                         task.status = TaskStatus::Completed;
+                        return true;
                     }
                     fs_ops::ProgressEvent::Error(e) => {
                         task.status = TaskStatus::Failed(e);
                     }
-                    fs_ops::ProgressEvent::Update(p) => task.status = TaskStatus::InProgress(p),
+                    fs_ops::ProgressEvent::Update(p) => {
+                        task.status = TaskStatus::InProgress(p)
+                    }
                 }
             }
         }
+        false
     }
 }
 

--- a/crates/ui/src/middle_pane.rs
+++ b/crates/ui/src/middle_pane.rs
@@ -19,8 +19,12 @@ fn get_icon_for_file(name: &str, is_dir: bool) -> &'static str {
         Some("toml") => "", // TOML
         Some("lock") => "", // Lock
         Some("git") | Some("gitignore") => "", // Git
-        Some("zip") | Some("rar") | Some("7z") => "", // Archive
-        Some("png") | Some("jpg") | Some("jpeg") | Some("gif") => "", // Image
+        // Audio
+        Some("mp3") | Some("wav") | Some("flac") => "🎵",
+        // Video
+        Some("mp4") | Some("avi") | Some("mkv") | Some("mov") => "🎞",
+        Some("zip") | Some("rar") | Some("7z") | Some("tar") | Some("gz") => "", // Archive
+        Some("png") | Some("jpg") | Some("jpeg") | Some("gif") | Some("webp") | Some("ico") => "", // Image
         Some("pdf") => "",   // PDF
         Some("txt") => "",   // Text file
         _ => "",           // Default file


### PR DESCRIPTION
The file list now refreshes immediately after a file is pasted or created, making the new file visible without a manual refresh.

The TaskManager now explicitly signals task completion to the main event loop.

Add icons for common file types

Added icons for audio (mp3, wav, flac) and video (mp4, avi, mkv, mov) files. Expanded existing icon categories for archives and images.